### PR TITLE
updated build.yml to run the workflow as soon as a new release is published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - release
+  release:
+    types: [published]
 
 jobs:
   publish-tauri:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build.yml` file to trigger workflows on release events.

Workflow trigger update:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R7-R8): Added a new trigger for release events with the type `published`.